### PR TITLE
Fix travis badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Starboard [![Build Status](https://magnum.travis-ci.com/heroku/starboard.svg?token=sCaMa7HeG4812XfRVVH2&branch=master)](https://magnum.travis-ci.com/heroku/starboard)
+# Starboard [![Build Status](https://travis-ci.org/heroku/starboard.svg)](https://travis-ci.org/heroku/starboard)
 
 **WARNING: This code is an early-access release; we wrote it for ourselves and it still harbors a lot of Herokuisms. You will probably have to adapt it to your needs if you want to use it.**
 


### PR DESCRIPTION
This repository is now public. Show the badge for travis for OSS.
Closes #2 

Note: I setup the notification hook already.
