### PR TITLE
Skip some cards or lists depending on source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 lannguage: ruby
 
 rvm:
-- 2.1.2
+- 2.1.5
 
 bundler_args: --without=development
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.1.2"
+ruby "2.1.5"
 
 gem "sinatra"
 gem "sinatra-contrib"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
-    backports (3.6.0)
+    backports (3.6.4)
     coffee-script (2.3.0)
       coffee-script-source
       execjs

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ Starboard depends on a specially-structured GitHub repository which contains the
 
 ## Starboard on Heroku
 
-First, you'll need to create a GitHub repository containing the guides themselves. More information about the format of this repository is available as part of the [template repository][1].
+First, you'll need to create a GitHub repository containing the guides themselves. [A template dir is provided][1]. More information about the format of this repository is available in [docs/guides.md][3].
 
 ### Security
 
@@ -76,3 +76,4 @@ curl -vvv -X POST -H "Content-type: application/json" -u <USERNAME> -H "X-GitHub
 
 [1]: https://GitHub.com/heroku/starboard-docs-template
 [2]: https://developer.GitHub.com/webhooks/creating/
+[3]: docs/guides.md

--- a/app.rb
+++ b/app.rb
@@ -34,7 +34,7 @@ class App < Sinatra::Base
             oauth: { id: ENV["HEROKU_OAUTH_ID"], secret: ENV["HEROKU_OAUTH_SECRET"] },
             secret: ENV["HEROKU_BOUNCER_SECRET"],
             herokai_only: true,
-            skip: ->(env) { ENV["HEROKAI_ONLY"] != "true"}
+            skip: ->(env) { ENV["HEROKAI_ONLY"] != "true" || env['PATH_INFO'] == '/guides' }
   end
 
   Excon.defaults[:middlewares] << Excon::Middleware::RedirectFollower

--- a/app/guides.rb
+++ b/app/guides.rb
@@ -23,7 +23,7 @@ class Guides
       Zip::File.open(guides_file.path) do |io|
         io.each do |entry|
           filename = entry.name.split('/')[1..-1].join('/')
-          next if entry.directory? 
+          next if entry.directory?
           refreshed_guides[:guides] << filename
           cache.set(filename, entry.get_input_stream.read)
         end
@@ -46,6 +46,7 @@ class Guides
   end
 
   def zip_response
-    http_client.get("https://:#{ENV['GITHUB_TOKEN']}@api.github.com/repos/#{ENV['GITHUB_REPO']}/zipball/master")
+    branch = ENV['GITHUB_BRANCH'] || 'master'
+    http_client.get("https://:#{ENV['GITHUB_TOKEN']}@api.github.com/repos/#{ENV['GITHUB_REPO']}/zipball/#{branch}")
   end
 end

--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -71,8 +71,8 @@ prepareForm = (data) ->
   )
   $('.controls').append ich.controls
     'teams': teamnames,
-    'onboarding_sources': starboard.information.onboarding_sources
-    'options': starboard.information.options
+    'onboarding_sources': (starboard.information.onboarding_sources || [])
+    'options': (starboard.information.options || [])
   $('#date').val(new Date().toDateInputValue())
 
   # hacky workaround to enable HTML5 Validation errors to appear with chosen

--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -69,7 +69,10 @@ prepareForm = (data) ->
   teamnames = _.map(root.starboard.teams.all(-> true), (team) ->
     {"name": team.model.id, "slug": team.model.slug}
   )
-  $('.controls').append(ich.controls({'teams': teamnames, 'onboarding_sources': starboard.information.onboarding_sources}))
+  $('.controls').append ich.controls
+    'teams': teamnames,
+    'onboarding_sources': starboard.information.onboarding_sources
+    'options': starboard.information.options
   $('#date').val(new Date().toDateInputValue())
 
   # hacky workaround to enable HTML5 Validation errors to appear with chosen
@@ -277,7 +280,7 @@ fillBoard = (trelloBoard, lists) ->
   )
   .then(->
     log.debug("Done building board: #{trelloBoard.url}")
-    # window.location.href = trelloBoard.url
+    window.location.href = trelloBoard.url
   ).catch((error) ->
     abortCreation("Unable to build board!", error)
   )
@@ -404,6 +407,9 @@ renderMarkdown = (rawmd) ->
 getValues = ->
   boarding_type = $("#boarding-type").val().split("-")[0]
   recruiting_source = $("#boarding-type").val().split("-")[1]
+  options = _.map($("[name='options[]']:checked"), (e) ->
+    $(e).val()
+  )
 
   {
     "name": $("#name").val(),
@@ -413,7 +419,8 @@ getValues = ->
     "employment_mode": $("#employment-mode").val(),
     "recruiting_source": recruiting_source,
     "boarding_type": boarding_type,
-    "tags": [recruiting_source],
+    "options": options,
+    "tags": _.union([recruiting_source], options),
   }
 
 $ ->

--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -69,7 +69,7 @@ prepareForm = (data) ->
   teamnames = _.map(root.starboard.teams.all(-> true), (team) ->
     {"name": team.model.id, "slug": team.model.slug}
   )
-  $('.controls').append(ich.controls({'teams': teamnames}))
+  $('.controls').append(ich.controls({'teams': teamnames, 'onboarding_sources': starboard.information.onboarding_sources}))
   $('#date').val(new Date().toDateInputValue())
 
   # hacky workaround to enable HTML5 Validation errors to appear with chosen

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,91 @@
+# Starboard documentation template
+
+[Starboard][1] is a tool which creates Trello boards for tracking the various tasks necessary when onboarding, offboarding, or crossboarding employees. We use it extensively within Heroku.
+
+This repository is a template for the guides you'll need to author for using Starboard in your organization.
+
+Fork this repository and add your own onboarding/offboarding/crossboarding guides.
+
+## How do I format content in this repo?
+
+First, you'll need to author your `data.json` file. This manifest is the core of the parser. It provides some required metadata and specifies which teams require which documents.
+
+```JSON
+{
+  "teams": {
+    "id": "Heroku",
+    "slug": "heroku-teams",
+    "additional_paths": ["", "/extra"],
+    "children": [
+      {
+        "id": "Engineering",
+        "slug": "engineering",
+        "children": [
+          {"id": "Frontend", "slug": "backend"},
+          {"id": "Backend", "slug": "backend"}
+        ]
+      },
+      {
+        "id": "Marketing",
+        "slug": "marketing"
+      }
+    ]
+  },
+  "lists_order": ["Pre-Hire", "First Day", "First Week", "First Month"],
+  "onboarding_sources": [
+    {"id": "sfdc","title":"Transfer from mothership"},
+    {"id":"contractor", "title": "Contractor"}
+  ],
+  "options": [
+    {"id": "remote","title":"Remote worker"},
+    {"id":"manager", "title": "Manager"}
+  ]
+}
+```
+- `Teams` is a tree representing the teams in your company.
+  - `id` is actually the name of the team.
+  - `slug` the path-safe (lowercase, no spaces) team name. This is used to find the markdown guides for a given team.
+  - `additional_paths` is an array of paths to additional documents which will be sourced for this team. If you have guides which are relevant for multiple teams, you can put the common content in a separate file and pull it in using this property.
+  - `children` an array of sub-teams.
+- `lists_order` Different guides can create and contribute to multiple lists in the new board. Sometimes, the ordering of the list has some semantic value — for example, pre-hire, first day, etc. You can manually specify that ordering using lists_order.
+- `onboarding_sources` is a list of possible onboarding options.
+- `options` is a list of custom information about the employee (is she remote, is she a manager, ...)
+
+Those last two options permit to tag lists or cards to have specific ones for the users
+fulfilling the conditions.
+
+## How is the repository structured? (File Hierarchy)
+
+Onboarding files for a team will be all the files per team up to the root.
+So if you are in the team `engineers` you will have the onboarding files of engineers and heroku-teams, as well as any `onboarding.md` files located in directories specified by the `additional_paths` property of any team in the path.
+
+For example, if someone is joining the "engineers" team, we expect to have `/heroku-teams/engineers/onboarding.markdown`, `/heroku-teams/onboarding.markdown`, `/onboarding.markdown` and `/extra/onboarding.markdown`.
+
+If a file is missing, starboard will silently skip it.
+
+## Markdown file format
+
+See the `onboarding.markdown` located in the root directory for an example.
+
+You can target the same trello list from multiple files — for example, different teams might have cards to contribute to the "First Day" list. Take care to use the exact same list name everywhere!
+
+## How to tag cards or lists?
+
+Add ids from `onboarding_sources` or `options` into brackets and separate words by a space.
+Avoid putting two different onboarding sources on one card as to be created, the employee must fulfill all the tags.
+Example: `[contractor transfer]` is a bad idea as contractor and transfer are two
+onboarding sources.
+But `[contractor remote]` is just one onboarding and one option. This means that
+all the cards with these tags will only be created for a contractor which is remote.
+
+Markdown example:
+
+```
+## This card is for employees that are remote [remote]
+## This one for managers outside the us [manager no-us]
+### Checklist for transfers [transfer]
+- bla
+- bla
+```
+
+[1]: http://github.com/heroku/starboard

--- a/views/index.erb
+++ b/views/index.erb
@@ -41,9 +41,11 @@
     <p>
         <label for="boarding-type">Recruiting Source:</label>
         <select data-placeholder="Choose a boarding type" name="boarding-type" id="boarding-type" required="required">
-            <option value="onboarding">Onboarding</option>
-            <option value="offboarding">Offboarding</optioff>
-            <option value="crossboarding">Crossboarding</option>
+            <option value="onboarding">New Hire</option>
+            <option value="onboarding-sfdc">SFDC Transfer</option>
+            <option value="onboarding-contractor">Contractor</option>
+            <option value="crossboarding">Changing team</option>
+            <option value="offboarding">Leaving</option>
         </select>
     </p>
     <p>

--- a/views/index.erb
+++ b/views/index.erb
@@ -42,8 +42,9 @@
         <label for="boarding-type">Recruiting Source:</label>
         <select data-placeholder="Choose a boarding type" name="boarding-type" id="boarding-type" required="required">
             <option value="onboarding">New Hire</option>
-            <option value="onboarding-sfdc">SFDC Transfer</option>
-            <option value="onboarding-contractor">Contractor</option>
+            {{#onboarding_sources}}
+              <option value="onboarding-{{id}}">{{title}}</option>
+            {{/onboarding_sources}}
             <option value="crossboarding">Changing team</option>
             <option value="offboarding">Leaving</option>
         </select>

--- a/views/index.erb
+++ b/views/index.erb
@@ -63,6 +63,13 @@
         </select>
     </p>
     <p>
+      {{#options}}
+        <label for="{{id}}">
+          <input type="checkbox" id="{{id}}" name="options[]" value="{{id}}"> {{title}}
+        </label>
+      {{/options}}
+    </p>
+    <p>
         <input class="button" type="submit" value="Create Trello Board">
         <div class="working hidden">
             <div class="spinner">


### PR DESCRIPTION
Current sources for onboarding:
can be defined in data.json in your docs repo.

just add `onboarding_sources:[{id:'sfdc', title:'From SFDC'}]`
this will add an item under `onboarding New hire` with `from SFDC`

This is reflected in the recruiting source.

How to create a list or card that will work only for sfdc?
---------------------------------------------------------

```
# First Day
## Only for sfdc [sfdc]
```

The part into brackets serves as tags.
