### PR TITLE
Refactor promises to queue them

### DIFF
--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -296,7 +296,7 @@ fillBoard = (trelloBoard, lists) ->
     reorderLists(trelloBoard)
   ).then(->
     log.debug("Done building board: #{trelloBoard.url}")
-    # window.location.href = trelloBoard.url
+    window.location.href = trelloBoard.url
   ).catch((error) ->
     abortCreation("Unable to build board!", error)
   )

--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -270,21 +270,21 @@ fillBoard = (trelloBoard, lists) ->
       $('progress').attr('value', root.starboard.progress)
       trelloList.cards = list.cards
       trelloList)
-  ).then( (lists) =>
+  ).then( (lists) ->
     console.log("lists", lists)
     cards = []
     lists.reduce( (acc, list) ->
       acc.then( -> Promise.all(createCards(list)))
          .then( (listCards) -> cards = cards.concat(listCards))
     , Promise.resolve()).then(-> cards)
-  ).then((cards) =>
+  ).then((cards) ->
     console.log("cards", cards)
     checkLists = []
     cards.reduce( (acc, card) ->
       acc.then(-> Promise.all(createCheckLists(card)))
          .then((cardLists) -> checkLists =  checkLists.concat(cardLists))
     , Promise.resolve()).then(-> checkLists)
-  ).then((checkLists) =>
+  ).then((checkLists) ->
     console.log("checkLists", checkLists)
     items = []
     checkLists.reduce( (acc, list) ->

--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -273,21 +273,24 @@ fillBoard = (trelloBoard, lists) ->
   ).then( (lists) =>
     console.log("lists", lists)
     cards = []
-    for list in lists
-      cards = cards.concat createCards(list)
-    Promise.all(cards)
+    lists.reduce( (acc, list) ->
+      acc.then( -> Promise.all(createCards(list)))
+         .then( (listCards) -> cards = cards.concat(listCards))
+    , Promise.resolve()).then(-> cards)
   ).then((cards) =>
     console.log("cards", cards)
     checkLists = []
-    for card in cards
-      checkLists = checkLists.concat createCheckLists(card)
-    Promise.all(checkLists)
+    cards.reduce( (acc, card) ->
+      acc.then(-> Promise.all(createCheckLists(card)))
+         .then((cardLists) -> checkLists =  checkLists.concat(cardLists))
+    , Promise.resolve()).then(-> checkLists)
   ).then((checkLists) =>
     console.log("checkLists", checkLists)
     items = []
-    for checkList in checkLists
-      items = items.concat createCheckItems(checkList)
-    Promise.all(items)
+    checkLists.reduce( (acc, list) ->
+      acc.then(-> Promise.all(createCheckItems(list)))
+         .then((listItems) -> items = items.concat listItems)
+    , Promise.resolve()).then(-> Promise.all(items))
   ).then(->
     log.debug("Ordering the lists", lists)
     reorderLists(trelloBoard)

--- a/test/guides_test.rb
+++ b/test/guides_test.rb
@@ -26,7 +26,8 @@ class GuidesTest < MiniTest::Unit::TestCase
     guides = Guides.new(cache)
     guides.http_client = HttpClient
     guides.refresh
-    assert_equal HttpClient.args.first, "https://:github_token@api.github.com/repos/ys/markdown/zipball/master"
+    assert_equal HttpClient.args.first, "https://api.github.com/repos/ys/markdown/zipball/master"
+    assert_equal HttpClient.args.last[:headers]["Authorization"], "token github_token"
   end
 
   def cache

--- a/views/index.erb
+++ b/views/index.erb
@@ -7,7 +7,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.5.2/underscore-min.js"></script>
     <!-- <script src="//cdnjs.cloudflare.com/ajax/libs/marked/0.3.0/marked.min.js"></script> -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/ICanHaz.js/0.10.3/ICanHaz.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/bluebird/1.2.2/bluebird.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/2.9.25/bluebird.js"></script>
     <script src="scripts/loglevel.min.js"></script>
     <script src="scripts/chosen.jquery.min.js"></script>
     <script src="scripts/TreeModel.min.js"></script>


### PR DESCRIPTION
Create checklists per card and wait for a card to succeed before next, same for checklist items.

This permits to slow down the query rate and go under the rate limit of Trello.