### PR TITLE
Fix ordering of checklist items

### DIFF
--- a/assets/javascripts/app.coffee
+++ b/assets/javascripts/app.coffee
@@ -366,7 +366,7 @@ createCheckItems = (checklist) ->
   _.reduce(checklist.items, (promise, item, index) ->
     promise.then(->
       Trello.postAsync("/checklists/#{checklist.id}/checkItems",
-                    { "name": item, 'pos': index })
+                    { "name": item, 'pos': index + 1 })
       .then(->
         log.debug ("Created checkItem '#{item}'")
         root.starboard.progress += 1


### PR DESCRIPTION
The Trello API expects a positive number (https://developers.trello.com/reference/#checklistsidcheckitems). At the moment we're passing 0,1,2... so the _second_ item ends up in position 1, etc. The first item gets pushed all the way to the bottom.